### PR TITLE
update readme and fix bitmap not loading on debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 This repository contains the code for a tool that helps with timing clicks manually. This project is written in Python 3.
 
 ## Packages
-This project uses several third-party packages. These can be found in ```requirements.txt```. To install the packages all at once, the following command can be run: ```pip install --no-cache-dir -r requirements.txt```. Keep in mind that you need to have installed python3-pip for this to work.
+This project uses several third-party packages. These can be found in ```requirements.txt```. To install the packages all at once, the following command can be run: ```pip install --no-cache-dir -r requirements.txt```. Keep in mind that you need to have installed python3-pip for this to work. Next to pip-installable dependencies, the project also depends on `tkinter`. This can be installed with the package manager, package name being `python3.x-tkinter` or `python3.x-tk`, substituting x for the current python version.\
+For example on debian: `sudo apt-get -yqq install python3.9-tk`. 
 
 ## Run Snipetool
 To run this tool, follow these steps in the command line or terminal:

--- a/snipetool.py
+++ b/snipetool.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import _tkinter
 import tkinter as tk
 
 from widgets.bar import Bar
@@ -38,7 +39,11 @@ class SnipeTool:
         self.window.attributes('-topmost', True)
         self.window.geometry(self.standard_size)
         self.window.title("Bottenkraker Snipetool")
-        self.window.wm_iconbitmap('images/icon.ico')
+        try:
+            self.window.wm_iconbitmap('images/icon.ico')
+        except _tkinter.TclError:
+            # Failed to load bitmap, this is not a fatal error
+            pass
 
         # Bar
         bar_canvas = self.bar.setup_window()


### PR DESCRIPTION
I was unable to make the project work without installing `python3.10-tkinter`, and then the project crashed on trying to load a bitmap that I think is meant for windows:
```
images/icon.ico: MS Windows icon resource - 5 icons, 16x16, 32 bits/pixel, 24x24, 32 bits/pixel
```

After implementing the changes in this PR, I was able to make the tool work on my machine. 